### PR TITLE
pass the minimum session timeout as a parameter.

### DIFF
--- a/src/main/java/org/I0Itec/zkclient/ZkServer.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkServer.java
@@ -36,6 +36,7 @@ public class ZkServer {
 
     public static final int DEFAULT_PORT = 2181;
     public static final int DEFAULT_TICK_TIME = 5000;
+    public static final int DEFAULT_MIN_SESSION_TIMEOUT = 2 * DEFAULT_TICK_TIME;
 
     private String _dataDir;
     private String _logDir;
@@ -47,6 +48,7 @@ public class ZkServer {
     private ZkClient _zkClient;
     private int _port;
     private int _tickTime;
+    private int _minSessionTimeout;
 
     public ZkServer(String dataDir, String logDir, IDefaultNameSpace defaultNameSpace) {
         this(dataDir, logDir, defaultNameSpace, DEFAULT_PORT);
@@ -55,13 +57,17 @@ public class ZkServer {
     public ZkServer(String dataDir, String logDir, IDefaultNameSpace defaultNameSpace, int port) {
         this(dataDir, logDir, defaultNameSpace, port, DEFAULT_TICK_TIME);
     }
+   public ZkServer(String dataDir, String logDir, IDefaultNameSpace defaultNameSpace, int port, int tickTime) {
+      this(dataDir, logDir, defaultNameSpace, port, tickTime, DEFAULT_MIN_SESSION_TIMEOUT);
+   }
 
-    public ZkServer(String dataDir, String logDir, IDefaultNameSpace defaultNameSpace, int port, int tickTime) {
+    public ZkServer(String dataDir, String logDir, IDefaultNameSpace defaultNameSpace, int port, int tickTime, int minSessionTimeout) {
         _dataDir = dataDir;
         _logDir = logDir;
         _defaultNameSpace = defaultNameSpace;
         _port = port;
         _tickTime = tickTime;
+       _minSessionTimeout = minSessionTimeout;
     }
 
     public int getPort() {
@@ -125,6 +131,7 @@ public class ZkServer {
     private void startSingleZkServer(final int tickTime, final File dataDir, final File dataLogDir, final int port) {
         try {
             _zk = new ZooKeeperServer(dataDir, dataLogDir, tickTime);
+           _zk.setMinSessionTimeout(_minSessionTimeout);
             _nioFactory = new NIOServerCnxn.Factory(new InetSocketAddress(port));
             _nioFactory.startup(_zk);
         } catch (IOException e) {

--- a/src/test/java/org/I0Itec/zkclient/TestUtil.java
+++ b/src/test/java/org/I0Itec/zkclient/TestUtil.java
@@ -93,15 +93,11 @@ public class TestUtil {
     }
 
     public static ZkServer startZkServer(String testName, int port) throws IOException {
-        return startZkServer(testName, port, ZkServer.DEFAULT_TICK_TIME);
-    }
-
-    public static ZkServer startZkServer(String testName, int port, int tickTime) throws IOException {
         String dataPath = "./build/test/" + testName + "/data";
         String logPath = "./build/test/" + testName + "/log";
         FileUtils.deleteDirectory(new File(dataPath));
         FileUtils.deleteDirectory(new File(logPath));
-        ZkServer zkServer = new ZkServer(dataPath, logPath, mock(IDefaultNameSpace.class), port, tickTime);
+        ZkServer zkServer = new ZkServer(dataPath, logPath, mock(IDefaultNameSpace.class), port, ZkServer.DEFAULT_TICK_TIME, 100);
         zkServer.start();
         return zkServer;
     }


### PR DESCRIPTION
If the min session timeout is not set, Zookeeper uses the tick time x2, which is 10 seconds for the test Zk Server.
Many test cases try to set  a smaller session timeout that was not accepted by the server.
