### PR TITLE
ISSUE-38: Checking for SaslAuthenticated event when connecting.

### DIFF
--- a/src/main/java/org/I0Itec/zkclient/ZkClient.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkClient.java
@@ -941,6 +941,10 @@ public class ZkClient implements Watcher {
                     return false;
                 }
                 stillWaiting = getEventLock().getStateChangedCondition().awaitUntil(timeout);
+                // Throw an exception in the case authorization fails
+                if (_currentState == KeeperState.AuthFailed) {
+                    throw new ZkException("Authentication failure");
+                }
             }
             LOG.debug("State is " + _currentState);
             return true;

--- a/src/main/java/org/I0Itec/zkclient/ZkClient.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkClient.java
@@ -124,11 +124,11 @@ public class ZkClient implements Watcher {
     public ZkClient(IZkConnection connection, int connectionTimeout) {
         this(connection, connectionTimeout, new SerializableSerializer());
     }
-    
+
     public ZkClient(IZkConnection zkConnection, int connectionTimeout, ZkSerializer zkSerializer) {
         this(zkConnection, connectionTimeout, zkSerializer, -1);
     }
-    
+
     /**
      * 
      * @param zkConnection

--- a/src/main/java/org/I0Itec/zkclient/ZkClient.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkClient.java
@@ -118,10 +118,18 @@ public class ZkClient implements Watcher {
         this(connection, connectionTimeout, new SerializableSerializer());
     }
 
+    public ZkClient(IZkConnection connection, int connectionTimeout, boolean isSaslAuthenticated) {
+        this(connection, connectionTimeout, new SerializableSerializer(), isSaslAuthenticated);
+    }
+    
     public ZkClient(IZkConnection zkConnection, int connectionTimeout, ZkSerializer zkSerializer) {
         this(zkConnection, connectionTimeout, zkSerializer, -1);
     }
 
+    public ZkClient(IZkConnection zkConnection, int connectionTimeout, ZkSerializer zkSerializer, boolean isSaslAuthenticated) {
+        this(zkConnection, connectionTimeout, zkSerializer, -1, isSaslAuthenticated);
+    }
+    
     /**
      * 
      * @param zkConnection
@@ -138,13 +146,34 @@ public class ZkClient implements Watcher {
      *            "retry forever until a connection has been reestablished".
      */
     public ZkClient(final IZkConnection zkConnection, final int connectionTimeout, final ZkSerializer zkSerializer, final long operationRetryTimeout) {
+        this(zkConnection, connectionTimeout, zkSerializer, operationRetryTimeout, false);
+    }
+    
+    /**
+     * 
+     * @param zkConnection
+     *            The Zookeeper servers
+     * @param connectionTimeout
+     *            The connection timeout in milli seconds
+     * @param zkSerializer
+     *            The Zookeeper data serializer
+     * @param operationRetryTimeout
+     *            Most operations done through this {@link org.I0Itec.zkclient.ZkClient} are retried in cases like
+     *            connection loss with the Zookeeper servers. During such failures, this
+     *            <code>operationRetryTimeout</code> decides the maximum amount of time, in milli seconds, each
+     *            operation is retried. A value lesser than 0 is considered as
+     *            "retry forever until a connection has been reestablished".
+     * @param isSaslAuthenticated
+     *            Waits on the SaslAuthenticated event instead of the SyncConnected event from ZooKeeper.
+     */
+    public ZkClient(final IZkConnection zkConnection, final int connectionTimeout, final ZkSerializer zkSerializer, final long operationRetryTimeout, boolean isSaslAuthenticated) {
         if (zkConnection == null) {
             throw new NullPointerException("Zookeeper connection is null!");
         }
         _connection = zkConnection;
         _zkSerializer = zkSerializer;
         this.operationRetryTimeoutInMillis = operationRetryTimeout;
-        connect(connectionTimeout, this);
+        connect(connectionTimeout, this, isSaslAuthenticated);
     }
 
     public void setZkSerializer(ZkSerializer zkSerializer) {
@@ -886,6 +915,10 @@ public class ZkClient implements Watcher {
         return waitForKeeperState(KeeperState.SyncConnected, time, timeUnit);
     }
 
+    public boolean waitUntilConnectedWithSasl(long time, TimeUnit timeUnit) throws ZkInterruptedException {
+        return waitForKeeperState(KeeperState.SaslAuthenticated, time, timeUnit);
+    }
+    
     public boolean waitForKeeperState(KeeperState keeperState, long time, TimeUnit timeUnit) throws ZkInterruptedException {
         if (_zookeeperEventThread != null && Thread.currentThread() == _zookeeperEventThread) {
             throw new IllegalArgumentException("Must not be done in the zookeeper event thread.");
@@ -1170,6 +1203,23 @@ public class ZkClient implements Watcher {
      *             if the connection timed out due to thread interruption
      */
     public void connect(final long maxMsToWaitUntilConnected, Watcher watcher) throws ZkInterruptedException, ZkTimeoutException, IllegalStateException {
+        connect(maxMsToWaitUntilConnected, watcher, false);
+    }
+    
+    /**
+     * Connect to ZooKeeper.
+     * 
+     * @param maxMsToWaitUntilConnected
+     * @param watcher
+     * @param isSaslAuthenticated
+     * @throws ZkInterruptedException
+     *             if the connection timed out due to thread interruption
+     * @throws ZkTimeoutException
+     *             if the connection timed out
+     * @throws IllegalStateException
+     *             if the connection timed out due to thread interruption
+     */
+    public void connect(final long maxMsToWaitUntilConnected, Watcher watcher, boolean isSaslAuthenticated) throws ZkInterruptedException, ZkTimeoutException, IllegalStateException {
         boolean started = false;
         acquireEventLock();
         try {
@@ -1179,7 +1229,13 @@ public class ZkClient implements Watcher {
             _connection.connect(watcher);
 
             LOG.debug("Awaiting connection to Zookeeper server");
-            if (!waitUntilConnected(maxMsToWaitUntilConnected, TimeUnit.MILLISECONDS)) {
+            boolean waitSuccessful = false;
+            if(isSaslAuthenticated) {
+                waitSuccessful = waitUntilConnectedWithSasl(maxMsToWaitUntilConnected, TimeUnit.MILLISECONDS);
+            } else {
+                waitSuccessful = waitUntilConnected(maxMsToWaitUntilConnected, TimeUnit.MILLISECONDS);
+            }
+            if (!waitSuccessful) {
                 throw new ZkTimeoutException("Unable to connect to zookeeper server within timeout: " + maxMsToWaitUntilConnected);
             }
             started = true;

--- a/src/main/java/org/I0Itec/zkclient/ZkClient.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkClient.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Date;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -29,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 
-import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
 import org.I0Itec.zkclient.ZkEventThread.ZkEvent;

--- a/src/main/java/org/I0Itec/zkclient/ZkClient.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkClient.java
@@ -889,8 +889,14 @@ public class ZkClient implements Watcher {
         boolean zkSaslEnabled = Boolean.parseBoolean(System.getProperty(ZK_SASL_CLIENT, "true"));
         String zkLoginContextName = System.getProperty(ZK_LOGIN_CONTEXT_NAME_KEY, "Client");
 
+        if(!zkSaslEnabled) {
+            LOG.warn("Client SASL has been explicitly disabled with " + ZK_SASL_CLIENT);
+            return false;
+        }
+
         String loginConfigFile = System.getProperty(JAVA_LOGIN_CONFIG_PARAM);
         if (loginConfigFile != null && loginConfigFile.length() > 0) {
+            LOG.info("JAAS File name: " + loginConfigFile);
             File configFile = new File(loginConfigFile);
             if (!configFile.canRead()) {
                 throw new IllegalArgumentException("File " + loginConfigFile + "cannot be read.");
@@ -902,14 +908,7 @@ public class ZkClient implements Watcher {
             } catch (Exception e) {
                 throw new ZkException(e);
             }
-            if (isSecurityEnabled && !zkSaslEnabled) {
-                LOG.error("JAAS file is present, but system property " + 
-                            ZK_SASL_CLIENT + " is set to false, which disables " +
-                            "SASL in the ZooKeeper client");
-                throw new IllegalArgumentException("Exception while determining if ZooKeeper is secure");
-            }
         }
-        LOG.info("Is security enabled: " + isSecurityEnabled);
         return isSecurityEnabled;
     }
 

--- a/src/main/java/org/I0Itec/zkclient/ZkClient.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkClient.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -28,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 
+import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
 import org.I0Itec.zkclient.ZkEventThread.ZkEvent;
@@ -78,6 +80,7 @@ public class ZkClient implements Watcher {
     private Thread _zookeeperEventThread;
     private ZkSerializer _zkSerializer;
     private volatile boolean _closed;
+    private boolean _isZkSaslEnabled;
 
     public ZkClient(String serverstring) {
         this(serverstring, Integer.MAX_VALUE);
@@ -150,6 +153,7 @@ public class ZkClient implements Watcher {
         _connection = zkConnection;
         _zkSerializer = zkSerializer;
         this.operationRetryTimeoutInMillis = operationRetryTimeout;
+        _isZkSaslEnabled = isZkSaslEnabled();
         connect(connectionTimeout, this);
     }
 
@@ -917,7 +921,7 @@ public class ZkClient implements Watcher {
     }
 
     public boolean waitUntilConnected(long time, TimeUnit timeUnit) throws ZkInterruptedException {
-        if (isZkSaslEnabled()) {
+        if (_isZkSaslEnabled) {
             return waitForKeeperState(KeeperState.SaslAuthenticated, time, timeUnit);
         } else {
             return waitForKeeperState(KeeperState.SyncConnected, time, timeUnit);

--- a/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
+++ b/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
@@ -22,6 +22,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import javax.security.auth.login.Configuration;
+
+import org.I0Itec.zkclient.exception.ZkException;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.junit.After;
@@ -30,55 +33,125 @@ import org.junit.Test;
 import org.junit.Assert;
 
 public class SaslAuthenticatedTest {
-    protected ZkClient _client;
-    protected ZkServer _zkServer;
-    protected static final Logger LOG = Logger.getLogger(AbstractAuthTest.class);
+    protected static final Logger LOG = Logger.getLogger(SaslAuthenticatedTest.class);
     static final String JAVA_LOGIN_CONFIG_PARAM = "java.security.auth.login.config";
     static final String ZK_AUTH_PROVIDER = "zookeeper.authProvider.1";
-    final String zkServerContextName = "Server";
-    final String zkClientContextName = "Client";
-    final String userSuperPasswd = "adminpasswd";
-    final String user = "fpj";
-    final String userPasswd = "fpjsecret";
-    final String zkModule = "org.apache.zookeeper.server.auth.DigestLoginModule";
-    
+    static final String ZK_ALLOW_FAILED_SASL = "zookeeper.allowSaslFailedClients";
+    public static final String ZK_LOGIN_CONTEXT_NAME_KEY = "zookeeper.sasl.clientconfig";
+
+    private int _port = 4700;
+    private ZkClient _client;
+    private ZkServer _zkServer;
+    private String _zkServerContextName = "Server";
+    private String _zkClientContextName = "Client";
+    private String _userSuperPasswd = "adminpasswd";
+    private String _userServerSide = "fpj";
+    private String _userClientSide = "fpj";
+    private String _userServerSidePasswd = "fpjsecret";
+    private String _userClientSidePasswd = "fpjsecret";
+    private String _zkModule = "org.apache.zookeeper.server.auth.DigestLoginModule";
+
     private String createJaasFile() throws IOException {
         File jaasFile = File.createTempFile("jaas", "conf");
         FileOutputStream jaasOutputStream = new java.io.FileOutputStream(jaasFile);
-        jaasOutputStream.write(String.format("%s {\n\t%s required\n", zkServerContextName, zkModule).getBytes());
-        jaasOutputStream.write(String.format("\tuser_super=\"%s\"\n", userSuperPasswd).getBytes());
-        jaasOutputStream.write(String.format("\tuser_%s=\"%s\";\n};\n\n", user, userPasswd).getBytes());
-        jaasOutputStream.write(String.format("%s {\n\t%s required\n", zkClientContextName, zkModule).getBytes());
-        jaasOutputStream.write(String.format("\tusername=\"%s\"\n", user).getBytes());
-        jaasOutputStream.write(String.format("\tpassword=\"%s\";\n};", userPasswd).getBytes());
+        jaasOutputStream.write(String.format("%s {\n\t%s required\n", _zkServerContextName, _zkModule).getBytes());
+        jaasOutputStream.write(String.format("\tuser_super=\"%s\"\n", _userSuperPasswd).getBytes());
+        jaasOutputStream.write(String.format("\tuser_%s=\"%s\";\n};\n\n", _userServerSide, _userServerSidePasswd).getBytes());
+        jaasOutputStream.write(String.format("%s {\n\t%s required\n", _zkClientContextName, _zkModule).getBytes());
+        jaasOutputStream.write(String.format("\tusername=\"%s\"\n", _userClientSide).getBytes());
+        jaasOutputStream.write(String.format("\tpassword=\"%s\";\n};", _userClientSidePasswd).getBytes());
         jaasOutputStream.close();
         jaasFile.deleteOnExit();
         return jaasFile.getAbsolutePath();
     }
 
     @Before
-    public void setUp() throws Exception {
-        String jaasFileName = createJaasFile();
-        LOG.info("Jaas file name " + jaasFileName);
-        System.setProperty(JAVA_LOGIN_CONFIG_PARAM, jaasFileName);
+    public void setUp() throws IOException {
         System.setProperty(ZK_AUTH_PROVIDER, "org.apache.zookeeper.server.auth.SASLAuthenticationProvider");
-        _zkServer = TestUtil.startZkServer("ZkClientTest", 4711);
-        _client = new ZkClient(new ZkConnection("localhost:4711", 6000), 6000);
+
+        // Reset all variables used for the jaas login file
+        this._zkServerContextName = "Server";
+        this._zkClientContextName = "Client";
+        this._userSuperPasswd = "adminpasswd";
+        this._userServerSide = "fpj";
+        this._userClientSide = "fpj";
+        this._userServerSidePasswd = "fpjsecret";
+        this._userClientSidePasswd = "fpjsecret";
+        this._zkModule = "org.apache.zookeeper.server.auth.DigestLoginModule";
     }
 
     @After
-    public void tearDown() throws Exception {
-        if(_client != null) {
-            _client.close();
+    public void tearDown() {
+        if(_zkServer != null) {
+            _zkServer.shutdown();
         }
-        _zkServer.shutdown();
         System.clearProperty(ZK_AUTH_PROVIDER);
         System.clearProperty(JAVA_LOGIN_CONFIG_PARAM);
     }
-    
+
+    private void bootstrap() throws IOException {
+        Configuration.setConfiguration(null);
+        String jaasFileName = createJaasFile();
+        System.setProperty(JAVA_LOGIN_CONFIG_PARAM, jaasFileName);
+        _zkServer = TestUtil.startZkServer("ZkClientTest", _port);
+        _client = _zkServer.getZkClient();
+    }
+
+    /**
+     * Tests that a connection authenticates successfully.
+     */
     @Test
     public void testConnection() {
-        _client.createPersistent("/test", new byte[0], Ids.CREATOR_ALL_ACL);
-        Assert.assertTrue(_client.exists("/test"));
+        try {
+            bootstrap();
+            _client.createPersistent("/test", new byte[0], Ids.CREATOR_ALL_ACL);
+            Assert.assertTrue(_client.exists("/test"));
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Tests that ZkClient spots the AuthFailed event in the
+     * case the property to allow failed SASL connections is
+     * enabled.
+     */
+    @Test
+    public void testAuthFailureFailedSasl() {
+        System.setProperty(ZK_ALLOW_FAILED_SASL, "true");
+        try {
+            testAuthFailure();
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        } finally {
+            System.clearProperty(ZK_ALLOW_FAILED_SASL);
+        }
+    }
+
+    /**
+     * Tests that ZkClient throws an exception in the case ZooKeeper
+     * keeps dropping the connection due to authentication failures.
+     */
+    @Test
+    public void testAuthFailureDisconnect() {
+        try {
+            testAuthFailure();
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    private void testAuthFailure() throws IOException {
+        _userServerSide = "otheruser";
+        String jaasFileName = createJaasFile();
+        System.setProperty(JAVA_LOGIN_CONFIG_PARAM, jaasFileName);
+        try {
+            bootstrap();
+            Assert.fail("Should have thrown an exception");
+        } catch (ZkException e) {
+            // expected
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
     }
 }

--- a/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
+++ b/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
@@ -141,6 +141,25 @@ public class SaslAuthenticatedTest {
         }
     }
 
+    @Test
+    public void testUnauthenticatedClient(){
+        ZkClient unauthed = null;
+
+        try {
+            bootstrap();
+            System.clearProperty(JAVA_LOGIN_CONFIG_PARAM);
+            System.setProperty("zookeeper.sasl.client", "false");
+            unauthed = new ZkClient("localhost:" + _port, 6000);
+            unauthed.createPersistent("/test", new byte[0], Ids.OPEN_ACL_UNSAFE);
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        } finally {
+            if (unauthed != null) {
+                unauthed.close();
+            }
+        }     
+    }
+
     private void testAuthFailure() throws IOException {
         _userServerSide = "otheruser";
         String jaasFileName = createJaasFile();

--- a/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
+++ b/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.I0Itec.zkclient;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.apache.log4j.Logger;
+import org.apache.zookeeper.ZooDefs.Ids;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Assert;
+
+public class SaslAuthenticatedTest {
+    protected ZkClient _client;
+    protected ZkServer _zkServer;
+    protected static final Logger LOG = Logger.getLogger(AbstractAuthTest.class);
+    static final String JAVA_LOGIN_CONFIG_PARAM = "java.security.auth.login.config";
+    static final String ZK_AUTH_PROVIDER = "zookeeper.authProvider.1";
+    final String zkServerContextName = "Server";
+    final String zkClientContextName = "Client";
+    final String userSuperPasswd = "adminpasswd";
+    final String user = "fpj";
+    final String userPasswd = "fpjsecret";
+    final String zkModule = "org.apache.zookeeper.server.auth.DigestLoginModule";
+    
+    private String createJaasFile() throws IOException {
+        File jaasFile = File.createTempFile("jaas", "conf");
+        FileOutputStream jaasOutputStream = new java.io.FileOutputStream(jaasFile);
+        jaasOutputStream.write(String.format("%s {\n\t%s required\n", zkServerContextName, zkModule).getBytes());
+        jaasOutputStream.write(String.format("\tuser_super=\"%s\"\n", userSuperPasswd).getBytes());
+        jaasOutputStream.write(String.format("\tuser_%s=\"%s\";\n};\n\n", user, userPasswd).getBytes());
+        jaasOutputStream.write(String.format("%s {\n\t%s required\n", zkClientContextName, zkModule).getBytes());
+        jaasOutputStream.write(String.format("\tusername=\"%s\"\n", user).getBytes());
+        jaasOutputStream.write(String.format("\tpassword=\"%s\";\n};", userPasswd).getBytes());
+        jaasOutputStream.close();
+        jaasFile.deleteOnExit();
+        return jaasFile.getAbsolutePath();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String jaasFileName = createJaasFile();
+        LOG.info("Jaas file name " + jaasFileName);
+        System.setProperty(JAVA_LOGIN_CONFIG_PARAM, jaasFileName);
+        System.setProperty(ZK_AUTH_PROVIDER, "org.apache.zookeeper.server.auth.SASLAuthenticationProvider");
+        _zkServer = TestUtil.startZkServer("ZkClientTest", 4711);
+        _client = new ZkClient(new ZkConnection("localhost:4711", 6000), 6000, true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if(_client != null) {
+            _client.close();
+        }
+        _zkServer.shutdown();
+        System.clearProperty(ZK_AUTH_PROVIDER);
+        System.clearProperty(JAVA_LOGIN_CONFIG_PARAM);
+    }
+    
+    @Test
+    public void testConnection() {
+        _client.createPersistent("/test", new byte[0], Ids.CREATOR_ALL_ACL);
+        Assert.assertTrue(_client.exists("/test"));
+    }
+}

--- a/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
+++ b/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
@@ -63,7 +63,7 @@ public class SaslAuthenticatedTest {
         System.setProperty(JAVA_LOGIN_CONFIG_PARAM, jaasFileName);
         System.setProperty(ZK_AUTH_PROVIDER, "org.apache.zookeeper.server.auth.SASLAuthenticationProvider");
         _zkServer = TestUtil.startZkServer("ZkClientTest", 4711);
-        _client = new ZkClient(new ZkConnection("localhost:4711", 6000), 6000, true);
+        _client = new ZkClient(new ZkConnection("localhost:4711", 6000), 6000);
     }
 
     @After

--- a/src/test/java/org/I0Itec/zkclient/ZkAuthTest.java
+++ b/src/test/java/org/I0Itec/zkclient/ZkAuthTest.java
@@ -18,6 +18,7 @@
 package org.I0Itec.zkclient;
 
 import junit.framework.Assert;
+
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;

--- a/src/test/java/org/I0Itec/zkclient/ZkAuthTest.java
+++ b/src/test/java/org/I0Itec/zkclient/ZkAuthTest.java
@@ -18,7 +18,6 @@
 package org.I0Itec.zkclient;
 
 import junit.framework.Assert;
-
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;

--- a/src/test/java/org/I0Itec/zkclient/ZkAuthTest.java
+++ b/src/test/java/org/I0Itec/zkclient/ZkAuthTest.java
@@ -17,15 +17,13 @@
  */
 package org.I0Itec.zkclient;
 
-import junit.framework.Assert;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.data.ACL;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
 
 public class ZkAuthTest extends AbstractAuthTest {
     @Override


### PR DESCRIPTION
Here is a suggestion of how to handle this issue. It adds new constructors to ZkClient to let the app specify whether it expects SASL authentication, and if positive, then it waits for the SaslAuthenticated event. 

Let me add a couple of notes to this issue:
1. I could do a patch that does not add constructors and instead detects the presence of the jaas login file. For this first cut, I opted for giving the option to the app, but I could switch to the other way. In fact, detecting the presence of the jaas file is typically the preferred mechanism.
2. The changes here right now don't do anything about the auth failure event. If the app is waiting for the SaslAuthenticated event and the event doesn't come because of an auth failure, then it will fail on a timeout because the waitForKeepeState method only checks for the specific state. To deal with it in a better way, or at least have a better error message, we would need to change the state transition handling.