### PR TITLE
exclude org.apache.jute and zookeeper.proto from imported packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ sourceCompatibility = 1.6
 
 jar {
     manifest {
-        attributes 'Implementation-Title': 'ZkClient', 'Implementation-Version': version
+        instruction 'Import-Package', '!org.apache.jute,!org.apache.zookeeper.proto, *' 
     }
 }
 


### PR DESCRIPTION
It was not possible to use zkClient in Karaf because these dependencies are not being exported from the Zookeeper bundle