### PR TITLE
Check that auth is enabled before throwing AuthFailed exception.

### DIFF
--- a/src/main/java/org/I0Itec/zkclient/ZkClient.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkClient.java
@@ -942,7 +942,7 @@ public class ZkClient implements Watcher {
                 }
                 stillWaiting = getEventLock().getStateChangedCondition().awaitUntil(timeout);
                 // Throw an exception in the case authorization fails
-                if (_currentState == KeeperState.AuthFailed) {
+                if (_currentState == KeeperState.AuthFailed && _isZkSaslEnabled) {
                     throw new ZkAuthFailedException("Authentication failure");
                 }
             }

--- a/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
+++ b/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
@@ -188,5 +188,13 @@ public class SaslAuthenticatedTest {
             }
         }
     }
-
+    
+    @Test
+    public void testNoZkJaasFile() throws IOException {
+        _zkClientContextName = "OtherClient";
+        _zkServerContextName = "OtherServer";
+        bootstrap();
+        _client.createPersistent("/test", new byte[0], Ids.OPEN_ACL_UNSAFE);
+        assertThat(_client.exists("/test")).isTrue();
+    }
 }

--- a/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
+++ b/src/test/java/org/I0Itec/zkclient/SaslAuthenticatedTest.java
@@ -191,10 +191,14 @@ public class SaslAuthenticatedTest {
     
     @Test
     public void testNoZkJaasFile() throws IOException {
-        _zkClientContextName = "OtherClient";
-        _zkServerContextName = "OtherServer";
-        bootstrap();
-        _client.createPersistent("/test", new byte[0], Ids.OPEN_ACL_UNSAFE);
-        assertThat(_client.exists("/test")).isTrue();
+        try {
+            _zkClientContextName = "OtherClient";
+            _zkServerContextName = "OtherServer";
+            bootstrap();
+            _client.createPersistent("/test", new byte[0], Ids.OPEN_ACL_UNSAFE);
+            assertThat(_client.exists("/test")).isTrue();
+        } catch (ZkAuthFailedException e) {
+            fail("Caught ZkAuthFailed exception and was not expecting it");
+        }
     }
 }


### PR DESCRIPTION
If the client detects a JAAS login file but it can't find a Client section, then it propagates an AuthFailed event up. We need to check that ZK auth is enabled before throwing the exception, otherwise we throw an exception even when we are not supposed to. I noticed this issue with kafka tests. In some tests, we set up the jaas login file for kafka, but not for zk, and the tests were failing without this change.