### PR TITLE
ISSUE-51: Adding missing license header.

### DIFF
--- a/src/test/java/org/I0Itec/zkclient/ZkStateChangeTest.java
+++ b/src/test/java/org/I0Itec/zkclient/ZkStateChangeTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.I0Itec.zkclient;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
I believe you folks should have replaced "the original author or authors" with dev names or a company, but I just copied it from another file. If you're to fix this, I suggest doing in a separate issue and for all files.