### PR TITLE
Remove slf4j-log4j12.jar from classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,19 +28,19 @@ repositories {
     //}
 }
 dependencies {
-    compile ('log4j:log4j:1.2.15') {
+    compile 'org.apache.zookeeper:zookeeper:3.4.8'
+    compile 'org.slf4j:slf4j-api:1.6.1'
+
+    testCompile 'commons-io:commons-io:1.4'
+    testCompile 'junit:junit:4.12'
+    testCompile ('log4j:log4j:1.2.15') {
         exclude group: "com.sun.jdmk", module: "jmxtools"
         exclude group: "com.sun.jmx", module: "jmxri"
         exclude group: "javax.jms", module: "jms"
     }
-    compile 'org.apache.zookeeper:zookeeper:3.4.8'
-    compile 'org.slf4j:slf4j-api:1.6.1'
-    compile 'org.slf4j:slf4j-log4j12:1.6.1'
-
-    testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:2.0.0'
-    testCompile 'commons-io:commons-io:1.4'
     testCompile 'org.mockito:mockito-core:1.8.0'
+    testCompile 'org.slf4j:slf4j-log4j12:1.6.1'
 
     //dependencies of mockito
     testCompile files('lib/objenesis-1.0.jar', 'lib/hamcrest-core-1.1.jar')

--- a/src/main/java/org/I0Itec/zkclient/ContentWatcher.java
+++ b/src/main/java/org/I0Itec/zkclient/ContentWatcher.java
@@ -20,7 +20,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.I0Itec.zkclient.exception.ZkNoNodeException;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @param <T>
@@ -28,7 +29,7 @@ import org.apache.log4j.Logger;
  */
 public final class ContentWatcher<T extends Object> implements IZkDataListener {
 
-    private static final Logger LOG = Logger.getLogger(ContentWatcher.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ContentWatcher.class);
 
     private Lock _contentLock = new ReentrantLock(true);
     private Condition _contentAvailable = _contentLock.newCondition();

--- a/src/main/java/org/I0Itec/zkclient/GatewayThread.java
+++ b/src/main/java/org/I0Itec/zkclient/GatewayThread.java
@@ -29,11 +29,12 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GatewayThread extends Thread {
 
-    protected final static Logger LOG = Logger.getLogger(GatewayThread.class);
+    protected final static Logger LOG = LoggerFactory.getLogger(GatewayThread.class);
 
     private final int _port;
     private final int _destinationPort;

--- a/src/main/java/org/I0Itec/zkclient/ZkClient.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkClient.java
@@ -41,7 +41,8 @@ import org.I0Itec.zkclient.exception.ZkTimeoutException;
 import org.I0Itec.zkclient.serialize.SerializableSerializer;
 import org.I0Itec.zkclient.serialize.ZkSerializer;
 import org.I0Itec.zkclient.util.ZkPathUtil;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.ConnectionLossException;
@@ -61,7 +62,7 @@ import org.apache.zookeeper.data.Stat;
  */
 public class ZkClient implements Watcher {
 
-    private final static Logger LOG = Logger.getLogger(ZkClient.class);
+    private final static Logger LOG = LoggerFactory.getLogger(ZkClient.class);
     protected static final String JAVA_LOGIN_CONFIG_PARAM = "java.security.auth.login.config";
     protected static final String ZK_SASL_CLIENT = "zookeeper.sasl.client";
     protected static final String ZK_LOGIN_CONTEXT_NAME_KEY = "zookeeper.sasl.clientconfig";

--- a/src/main/java/org/I0Itec/zkclient/ZkConnection.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkConnection.java
@@ -23,7 +23,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.I0Itec.zkclient.exception.ZkException;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
@@ -37,7 +38,7 @@ import org.apache.zookeeper.data.Stat;
 
 public class ZkConnection implements IZkConnection {
 
-    private static final Logger LOG = Logger.getLogger(ZkConnection.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ZkConnection.class);
 
     /** It is recommended to use quite large sessions timeouts for ZooKeeper. */
     private static final int DEFAULT_SESSION_TIMEOUT = 30000;

--- a/src/main/java/org/I0Itec/zkclient/ZkEventThread.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkEventThread.java
@@ -20,7 +20,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.I0Itec.zkclient.exception.ZkInterruptedException;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * All listeners registered at the {@link ZkClient} will be notified from this event thread. This is to prevent
@@ -32,7 +33,7 @@ import org.apache.log4j.Logger;
  */
 class ZkEventThread extends Thread {
 
-    private static final Logger LOG = Logger.getLogger(ZkEventThread.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ZkEventThread.class);
 
     private BlockingQueue<ZkEvent> _events = new LinkedBlockingQueue<ZkEvent>();
 

--- a/src/main/java/org/I0Itec/zkclient/ZkServer.java
+++ b/src/main/java/org/I0Itec/zkclient/ZkServer.java
@@ -25,13 +25,14 @@ import javax.annotation.PreDestroy;
 
 import org.I0Itec.zkclient.exception.ZkException;
 import org.I0Itec.zkclient.exception.ZkInterruptedException;
-import org.apache.log4j.Logger;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ZkServer {
 
-    private final static Logger LOG = Logger.getLogger(ZkServer.class);
+    private final static Logger LOG = LoggerFactory.getLogger(ZkServer.class);
 
     public static final int DEFAULT_PORT = 2181;
     public static final int DEFAULT_TICK_TIME = 5000;


### PR DESCRIPTION
It causes conflicts in many situations. E.g. log4j-over-slf4j.jar and slf4j-log4j12.jar cannot be present simultaneously. See http://www.slf4j.org/legacy.html for more details
